### PR TITLE
fix: replace `–` with `-`

### DIFF
--- a/.vscode/run.ps1
+++ b/.vscode/run.ps1
@@ -4,5 +4,5 @@ Param(
 )
 $log_file_path =  "log/$((Get-Date).ToString('yyyyMMdd_HHmmss')).log"
 $log_file_path
-Start-Process -Wait vvp.exe -ArgumentList "$vvp_file " –RedirectStandardOutput $log_file_path
+Start-Process -Wait vvp.exe -ArgumentList "$vvp_file " -RedirectStandardOutput $log_file_path
 gtkwave $wave_path


### PR DESCRIPTION
Start-Process : 找不到接受实际参数“鈥揜edirectStandardOutput”的位置形式参数。
所在位置 D:\gits\iverilog-vscode\.vscode\run.ps1:7 字符: 1
+ Start-Process -Wait vvp.exe -ArgumentList "$vvp_file " 鈥揜edirectStand ...
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidArgument: (:) [Start-Process]，ParameterBindingException
    + FullyQualifiedErrorId : PositionalParameterNotFound,Microsoft.PowerShell.Commands.StartProcessCommand

`–` => `-`